### PR TITLE
feat(dashboard): admin dashboard API with aggregated MongoDB and Redis statistics

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ const { connectRedis } = require('./config/redis')
 //Routes
 const authRoutes = require('./routes/authRoutes')
 const patientRoutes = require('./routes/patientRoutes')
+const dashboardRoutes = require('./routes/dashboardRoutes')
 
 const errorHandler = require('./middlewares/errorHandler')
 
@@ -43,6 +44,7 @@ app.get('/api/test', (req, res) => {
 // Mount routes
 app.use('/api/auth', authRoutes)
 app.use('/api/patients', patientRoutes)
+app.use('/api/dashboard', dashboardRoutes)
 
 
 // Error handling middleware - catches any thrown errors

--- a/src/controllers/dashboardController.js
+++ b/src/controllers/dashboardController.js
@@ -1,0 +1,52 @@
+const Patient = require('../models/Patient')
+const { getRedisClient } = require('../config/redis')
+
+exports.getAdminDashboard = async (req, res, next) => {
+    try {
+        // MongoDB: total patients count
+        const totalPatients = await Patient.countDocuments()
+
+        // MongoDB aggregation for average BMI (weight / height(m)^2)
+        const bmiAggregation = await Patient.aggregate([
+            {
+                $addFields: {
+                    bmi: { $divide: ['$weight', { $pow: [{ $divide: ['$height', 100] }, 2] }] },
+                },
+            },
+            {
+                $group: {
+                    _id: null,
+                    averageBMI: { $avg: '$bmi' },
+                },
+            },
+        ])
+
+        const averageBMI = bmiAggregation[0]?.averageBMI || 0
+
+        const redisClient = getRedisClient()
+
+        // Redis fetches - convert to integer or default 0
+        const [
+            reportsSentStr,
+            whatsappDeliveredStr,
+            crmSyncSuccessStr,
+            crmSyncFailureStr,
+        ] = await Promise.all([
+            redisClient.get('reportsSent'),
+            redisClient.get('whatsappDelivered'),
+            redisClient.get('crmSyncSuccess'),
+            redisClient.get('crmSyncFailure'),
+        ])
+
+        res.json({
+            totalPatients,
+            averageBMI: Number(averageBMI.toFixed(2)),
+            reportsSent: parseInt(reportsSentStr) || 0,
+            whatsappDelivered: parseInt(whatsappDeliveredStr) || 0,
+            crmSyncSuccess: parseInt(crmSyncSuccessStr) || 0,
+            crmSyncFailure: parseInt(crmSyncFailureStr) || 0,
+        })
+    } catch (error) {
+        next(error)
+    }
+}

--- a/src/routes/dashboardRoutes.js
+++ b/src/routes/dashboardRoutes.js
@@ -1,0 +1,10 @@
+const express = require('express')
+const { getAdminDashboard } = require('../controllers/dashboardController')
+const { protect, authorizeRoles } = require('../middlewares/authMiddleware')
+
+const router = express.Router()
+
+// Admin-only dashboard endpoint
+router.get('/admin', protect, authorizeRoles('admin'), getAdminDashboard)
+
+module.exports = router


### PR DESCRIPTION
- Implemented `/api/dashboard/admin` endpoint restricted to admin users.
- Aggregates total patient count and computes average BMI from MongoDB.
- Retrieves Redis counters for report sends, WhatsApp delivery, CRM sync successes, and failures.
- Returns structured JSON with these aggregated statistics.
- Protected route with JWT and admin role middleware.
- Tested successful retrieval and access control via Postman.
